### PR TITLE
Fix #36 / No warning on TailSpin (className + style)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # hoc-react-loader
-[![CircleCI](https://circleci.com/gh/Zenika/hoc-react-loader.svg?&style=shield&circle-token=07eae4d9bdbe138c04d32753312ba543a4e08f34)](https://circleci.com/gh/Zenika/hoc-react-loader/tree/master) [![NPM Version](https://badge.fury.io/js/hoc-react-loader.svg)](https://www.npmjs.com/package/hoc-react-loader) [![Coverage Status](https://coveralls.io/repos/github/Zenika/react-loader/badge.svg?branch=master)](https://coveralls.io/github/Zenika/react-loader?branch=master)
+[![CircleCI](https://circleci.com/gh/Zenika/hoc-react-loader.svg?&style=shield&circle-token=07eae4d9bdbe138c04d32753312ba543a4e08f34)](https://circleci.com/gh/Zenika/hoc-react-loader/tree/master) [![NPM Version](https://badge.fury.io/js/hoc-react-loader.svg)](https://www.npmjs.com/package/hoc-react-loader) [![Coverage Status](https://coveralls.io/repos/github/Zenika/hoc-react-loader/badge.svg?branch=master)](https://coveralls.io/github/Zenika/hoc-react-loader?branch=master)
 
 This is a higher order component ("HOC"). Its purpose is to call a `load` callback passed through the `props` of a component only once (at `componentWillMount`). This is convenient to load data from a backend for instance. The component shows a loading indicator when it's waiting for the props to be defined. The loading indicator can be changed easily.
 

--- a/src/TailSpin/TailSpin.jsx
+++ b/src/TailSpin/TailSpin.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, PropTypes } from 'react'
 import tinycolor from 'tinycolor2'
 
 /* global window */
@@ -41,9 +41,17 @@ class TailSpin extends Component {
 
   render() {
     const { color } = this.state
+    const { style, className } = this.props
 
     return (
-      <svg ref={(c) => { this.svg = c }} width="38" height="38" viewBox="0 0 38 38" xmlns="http://www.w3.org/2000/svg" {...this.props}>
+      <svg
+        ref={(c) => { this.svg = c }}
+        width="38" height="38"
+        viewBox="0 0 38 38"
+        xmlns="http://www.w3.org/2000/svg"
+        style={style}
+        className={className}
+      >
         <defs>
           <linearGradient x1="8.042%" y1="0%" x2="65.682%" y2="23.865%" id="a">
             <stop stopColor={color} stopOpacity=".2" offset="0%" />
@@ -78,6 +86,11 @@ class TailSpin extends Component {
       </svg>
     )
   }
+}
+
+TailSpin.propTypes = {
+  className: PropTypes.string,
+  style: PropTypes.object,
 }
 
 export default TailSpin

--- a/src/TailSpin/TailSpin.spec.js
+++ b/src/TailSpin/TailSpin.spec.js
@@ -51,6 +51,14 @@ describe('TailSpin', () => {
 
     testColor(mounted, '#76692f')
   })
+
+  it('shouldnt print a warning', () => {
+    mount(
+      <div style={{ backgroundColor: '#2D2812' }}>
+        <TailSpin dispatch="a dispatch" />
+      </div>
+    )
+  })
 })
 
 /* eslint-enable no-unused-expressions */


### PR DESCRIPTION
#36 

This PR purpose is to fix the issue #36.
This is not about the `render-callback` support.

@mpolichette I think you should rebase your PR with this one (after merge) if you want to add this `render-callback` support.

I tried to be as simple as possible since we take the choice of only using `className` and `style`