### PR TITLE
Hotfix / svg.parentNode fail with renderer.create(

### DIFF
--- a/build/TailSpin/TailSpin.js
+++ b/build/TailSpin/TailSpin.js
@@ -38,7 +38,7 @@ var TailSpin = function (_Component) {
     var _this = _possibleConstructorReturn(this, (TailSpin.__proto__ || Object.getPrototypeOf(TailSpin)).call(this, props));
 
     _this.setColor = function () {
-      var parent = _this.svg.parentNode;
+      var parent = _this.svg && _this.svg.parentNode;
       var parentColor = parent ? getBackgroundColor(parent) : undefined;
 
       while (parent && !parentColor) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoc-react-loader",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Higher order component to call a load function from props at mount.",
   "main": "build/index.js",
   "peerDependencies": {

--- a/src/TailSpin/TailSpin.jsx
+++ b/src/TailSpin/TailSpin.jsx
@@ -21,7 +21,7 @@ class TailSpin extends Component {
   }
 
   setColor = () => {
-    let parent = this.svg.parentNode
+    let parent = this.svg && this.svg.parentNode
     let parentColor = parent ? getBackgroundColor(parent) : undefined
 
     while (parent && !parentColor) {

--- a/src/TailSpin/TailSpin.spec.js
+++ b/src/TailSpin/TailSpin.spec.js
@@ -6,7 +6,7 @@
 */
 
 import React from 'react'
-import { shallow, mount } from 'enzyme'
+import { mount } from 'enzyme'
 import blanket from 'blanket' // eslint-disable-line
 import TailSpin from './TailSpin'
 
@@ -57,12 +57,6 @@ describe('TailSpin', () => {
       <div style={{ backgroundColor: '#2D2812' }}>
         <TailSpin dispatch="a dispatch" />
       </div>
-    )
-  })
-
-  it('should not crash when no color is found', () => {
-    shallow(
-      <TailSpin />
     )
   })
 })

--- a/src/TailSpin/TailSpin.spec.js
+++ b/src/TailSpin/TailSpin.spec.js
@@ -6,7 +6,7 @@
 */
 
 import React from 'react'
-import { mount } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import blanket from 'blanket' // eslint-disable-line
 import TailSpin from './TailSpin'
 
@@ -57,6 +57,12 @@ describe('TailSpin', () => {
       <div style={{ backgroundColor: '#2D2812' }}>
         <TailSpin dispatch="a dispatch" />
       </div>
+    )
+  })
+
+  it('should not crash when no color is found', () => {
+    shallow(
+      <TailSpin />
     )
   })
 })


### PR DESCRIPTION
I had this error with jest testing : 
```
    TypeError: Cannot read property 'parentNode' of null

      at TailSpin._this.setColor (node_modules\hoc-react-loader\build\TailSpin\TailSpin.js:41:29)
      at TailSpin.componentDidMount (node_modules\hoc-react-loader\build\TailSpin\TailSpin.js:68:12)
      at node_modules\react-test-renderer\lib\ReactCompositeComponent.js:265:25
```

with `renderer.create(` from `import renderer from 'react-test-renderer'`

So I add a check on this.svg DOM reference.